### PR TITLE
add link to flexcompute website

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -15,6 +15,7 @@ This is the documentation for the python API, which is the main way to build sim
    howdoi
    api
    changelog
+   Tidy3D Solver Technology <https://www.flexcompute.com/tidy3d/solver/>
 
 .. image:: _static/ring_resonator.png
    :width: 1200


### PR DESCRIPTION
this adds a link back to the flexcompute website

<img width="582" alt="image" src="https://github.com/flexcompute-readthedocs/tidy3d-docs/assets/92756888/ea08c50f-20d5-40a7-bf43-200a6b8451b7">

note: the screenshot was taken before I capitalized the link text for consistency.

Before we merge this, we should wait for Qing's approval.
